### PR TITLE
hdf5_tools.hpp: fix build failure with gcc-12.

### DIFF
--- a/include/fast5/hdf5_tools.hpp
+++ b/include/fast5/hdf5_tools.hpp
@@ -8,6 +8,7 @@
 #ifndef __HDF5_TOOLS_HPP
 #define __HDF5_TOOLS_HPP
 
+#include <array>
 #include <cassert>
 #include <cstring>
 #include <exception>


### PR DESCRIPTION
When attempting to build fast5 with gcc-12, for instance in current
debian experimental distribution, the build fails with the error
described in [Debian Bug#1012919].  Relevant messages are:

	[…]
	/<<PKGBUILDDIR>>/src/../include/fast5/hdf5_tools.hpp:2298:70:   required from here
	/usr/include/c++/12/type_traits:1135:52: error: static assertion failed: template argument must be a complete class or an unbounded array
	[…]
	/usr/include/c++/12/bits/stl_uninitialized.h:699:42: error: invalid use of incomplete type ‘std::iterator_traits<std::array<char, 1>*>::value_type’ {aka ‘struct std::array<char, 1>’}
	[…]

According to [gcc-12 porting guide], this looks to be a case of
missing inclusion of `<array>`.  The present commit fixes the build
error without visible regressions with older gcc versions.

[Debian Bug#1012919]: https://bugs.debian.org/1012919
[gcc-12 porting guide]: https://gcc.gnu.org/gcc-12/porting_to.html

Signed-off-by: Étienne Mollier <emollier@debian.org>